### PR TITLE
'Tests passed' chart changed to 'Tests total'.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,5 +71,12 @@
             <version>0.3.2</version>
             <scope>test</scope>
         </dependency>
+	<dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-war</artifactId>
+            <type>war</type>
+            <version>LATEST</version>
+            <scope>test</scope>
+	</dependency>
     </dependencies>
 </project>

--- a/src/main/java/hudson/plugins/report/jck/BuildReportExtended.java
+++ b/src/main/java/hudson/plugins/report/jck/BuildReportExtended.java
@@ -33,13 +33,17 @@ public class BuildReportExtended extends BuildReport {
     private final List<String> addedSuites;
     private final List<String> removedSuites;
     private final List<SuiteTestChanges> testChanges;
+    private final int total;
+    private final int notRun;
 
     public BuildReportExtended(int buildNumber, String buildName, int passed, int failed, int error, List<Suite> suites,
-            List<String> addedSuites, List<String> removedSuites, List<SuiteTestChanges> testChanges) {
-        super(buildNumber, buildName, passed, failed, error, suites);
+            List<String> addedSuites, List<String> removedSuites, List<SuiteTestChanges> testChanges, int total, int notRun) {
+        super(buildNumber, buildName, passed, failed, error, suites, total, notRun);
         this.addedSuites = addedSuites;
         this.removedSuites = removedSuites;
         this.testChanges = testChanges;
+        this.total = total;
+        this.notRun = notRun;
     }
 
     public List<String> getAddedSuites() {
@@ -52,6 +56,16 @@ public class BuildReportExtended extends BuildReport {
 
     public List<SuiteTestChanges> getTestChanges() {
         return testChanges;
+    }
+
+    @Override
+    public int getTotal(){
+        return total;
+    }
+
+    @Override
+    public int getNotRun(){
+        return notRun;
     }
 
 }

--- a/src/main/java/hudson/plugins/report/jck/BuildSummaryParser.java
+++ b/src/main/java/hudson/plugins/report/jck/BuildSummaryParser.java
@@ -147,6 +147,10 @@ public class BuildSummaryParser {
             notRun += suite.getReport().getTestsNotRun();
         }
 
+        if (prefixes.contains("jck")){
+           total -= notRun;
+        }
+
         return new BuildReport(build.getNumber(), build.getDisplayName(), passed, failed, error, suites, total, notRun);
     }
 

--- a/src/main/java/hudson/plugins/report/jck/BuildSummaryParser.java
+++ b/src/main/java/hudson/plugins/report/jck/BuildSummaryParser.java
@@ -136,14 +136,18 @@ public class BuildSummaryParser {
         int passed = 0;
         int failed = 0;
         int error = 0;
+        int total = 0;
+        int notRun = 0;
 
         for (Suite suite : suites) {
             passed += suite.getReport().getTestsPassed();
             failed += suite.getReport().getTestsFailed();
             error += suite.getReport().getTestsError();
+            total += suite.getReport().getTestsTotal();
+            notRun += suite.getReport().getTestsNotRun();
         }
 
-        return new BuildReport(build.getNumber(), build.getDisplayName(), passed, failed, error, suites);
+        return new BuildReport(build.getNumber(), build.getDisplayName(), passed, failed, error, suites, total, notRun);
     }
 
     public BuildReportExtended parseBuildReportExtended(Run<?, ?> build) throws Exception {
@@ -280,7 +284,9 @@ public class BuildSummaryParser {
                 currentReport.getSuites(),
                 addedSuites,
                 removedSuites,
-                result);
+                result,
+                currentReport.getTotal(),
+                currentReport.getNotRun());
     }
 
     private List<Suite> parseBuildSummary(Run<?, ?> build) throws Exception {

--- a/src/main/java/hudson/plugins/report/jck/BuildSummaryParser.java
+++ b/src/main/java/hudson/plugins/report/jck/BuildSummaryParser.java
@@ -150,6 +150,7 @@ public class BuildSummaryParser {
         if (prefixes.contains("jck")){
            total -= notRun;
         }
+        //jtreg need to have not runned tests included, but jck have to be excluded.
 
         return new BuildReport(build.getNumber(), build.getDisplayName(), passed, failed, error, suites, total, notRun);
     }

--- a/src/main/java/hudson/plugins/report/jck/model/BuildReport.java
+++ b/src/main/java/hudson/plugins/report/jck/model/BuildReport.java
@@ -72,7 +72,7 @@ public class BuildReport implements java.io.Serializable {
     }
 
     public int getTotal(){
-        return total - notRun;
+        return total;
     }
 
     public int getNotRun(){

--- a/src/main/java/hudson/plugins/report/jck/model/BuildReport.java
+++ b/src/main/java/hudson/plugins/report/jck/model/BuildReport.java
@@ -32,15 +32,19 @@ public class BuildReport implements java.io.Serializable {
     private final int passed;
     private final int failed;
     private final int error;
+    private final int total;
+    private final int notRun;
     private final List<Suite> suites;
 
-    public BuildReport(int buildNumber, String buildName, int passed, int failed, int error, List<Suite> suites) {
+    public BuildReport(int buildNumber, String buildName, int passed, int failed, int error, List<Suite> suites, int total, int notRun) {
         this.buildNumber = buildNumber;
         this.buildName = buildName;
         this.passed = passed;
         this.failed = failed;
         this.error = error;
         this.suites = suites;
+        this.total = total;
+        this.notRun = notRun;
     }
 
     public int getBuildNumber() {
@@ -65,6 +69,14 @@ public class BuildReport implements java.io.Serializable {
 
     public List<Suite> getSuites() {
         return suites;
+    }
+
+    public int getTotal(){
+        return total - notRun;
+    }
+
+    public int getNotRun(){
+        return notRun;
     }
 
 }

--- a/src/main/resources/hudson/plugins/report/jck/ReportProjectAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/report/jck/ReportProjectAction/floatingBox.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
     <h3 style="font-family: monospace">Number of Failures: ${action.displayName}</h3>
     <div id="jckErrorsFailuresChartContainer" style="margin-right: 10pt"><canvas id='jckErrorsFailuresChart' width='600' height='300'></canvas></div>
-    <h3 style="font-family: monospace">Number of Passed tests: ${action.displayName}</h3>
+    <h3 style="font-family: monospace">Number of Tests total: ${action.displayName}</h3>
     <div id="jckPassedChartContainer" style="margin-right: 10pt"><canvas id='jckPassedChart' width='600' height='300'></canvas></div>
     <h3 style="font-family: monospace">Regressions: ${action.displayName}</h3>
     <div id="jckRegressionsChartContainer" style="margin-right: 10pt"><canvas id='jckRegressionsChart' width='600' height='250'></canvas></div>
@@ -72,7 +72,7 @@
         ],
                 datasets: [
                 {
-                label: "Passed tests",
+                label: "Tests total",
                         fillColor: "rgba(180,180,180,0.2)",
                         strokeColor: "rgba(180,180,180,1)",
                         pointColor: "rgba(180,180,180,1)",
@@ -81,7 +81,7 @@
                         pointHighlightStroke: "rgba(180,180,180,1)",
                         data: [
         <j:forEach var="build" items="${jckReports.reports}" varStatus="status">
-            ${build.passed}<j:if test="${!status.last}">,</j:if>
+            ${build.total}<j:if test="${!status.last}">,</j:if>
         </j:forEach>
                         ]
                 }


### PR DESCRIPTION
Added notRun for jck builds and total for jck/jtreg.
floatingBox.jelly changed from 'passed' to 'total - notRun'.